### PR TITLE
Refactor recent history query

### DIFF
--- a/chat_hub/core/services/chat/message_service.go
+++ b/chat_hub/core/services/chat/message_service.go
@@ -58,13 +58,7 @@ func (s *MessageService) buildMessage(dialogue entity.UserDialogueEntity, userId
 }
 
 func (s *MessageService) GetMessageByDialogueId(dialogueId string, numberOfMessages int) ([]entity.MessageEntity, error) {
-	messageId, err := s.messageRepository.GetFarestUserMessageByDialogueId(dialogueId, numberOfMessages)
-	if err != nil {
-		log.Println("Error getting messages by dialogue ID: " + err.Error())
-		return nil, err
-	}
-
-	recentChatMessages, err := s.messageRepository.GetRecentChatMessagesByDialogueId(dialogueId, messageId)
+	recentChatMessages, err := s.messageRepository.GetRecentChatMessagesByDialogueId(dialogueId, numberOfMessages)
 	if err != nil {
 		log.Println("Error getting recent chat messages: " + err.Error())
 		return nil, err


### PR DESCRIPTION
## Summary
- combine queries for recent chat history retrieval
- update message service to use the single query

## Testing
- `go vet ./...` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c634a8f8c832e87466a7aa1bba47b