### PR TITLE
feat: add consumer for updating task tags

### DIFF
--- a/person_task_manager/server/src/core/domain/enums/kafka.enums.ts
+++ b/person_task_manager/server/src/core/domain/enums/kafka.enums.ts
@@ -16,6 +16,7 @@ export enum KafkaCommand {
     UPLOAD_FILE = 'uploadFile',
     UPLOAD_UPDATED_FILE = 'uploadUpdatedFile',
     UPDATE_TASK = 'updateTask',
+    UPDATE_TASK_TAG = 'updateTaskTag',
     DELETE_TASK = 'deleteTask',
     CREATE_COMMIT = 'createCommit',
     CREATE_SCHEDULE_TASK = 'scheduleGroupCreateTask',

--- a/person_task_manager/server/src/core/services/task.service.ts
+++ b/person_task_manager/server/src/core/services/task.service.ts
@@ -384,6 +384,14 @@ class TaskService {
         return null
     }
 
+    async updateTaskTag(taskId: string, tag: string): Promise<void> {
+        try {
+            await taskStore.updateTask(taskId, { tag: tag });
+        } catch (error) {
+            console.log("Error when update task tag", error);
+        }
+    }
+
     async getDoneTasks(userId: number, timeUnit: string): Promise<ITaskEntity[] | null> {
         try {
             let doneTasks = this.taskCache.get(InternalCacheConstants.DONE_TASKS + userId);

--- a/person_task_manager/server/src/infrastructure/kafka/kafka-controller.ts
+++ b/person_task_manager/server/src/infrastructure/kafka/kafka-controller.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import { KafkaConfig } from "./kafka-config";
 import { KafkaTopic } from "../../core/domain/enums/kafka.enums";
 import { handleGaiaCreateTaskMessage } from "../../ui/kafka/gaia-create-task.consumer";
+import { handleUpdateTaskTagMessage } from "../../ui/kafka/update-task-tag.consumer";
 
 dotenv.config({ path: "./src/.env" });
 
@@ -37,4 +38,5 @@ const getKafkaTopicsFromEnv = (): string[] => {
 
 const kafkaTopicHandlers: Record<string, (message: string) => void> = {
     [KafkaTopic.GAIA_CREATE_TASK]: (message: string) => handleGaiaCreateTaskMessage(message),
+    [KafkaTopic.UPDATE_TASK]: (message: string) => handleUpdateTaskTagMessage(message),
 };

--- a/person_task_manager/server/src/ui/kafka/update-task-tag.consumer.ts
+++ b/person_task_manager/server/src/ui/kafka/update-task-tag.consumer.ts
@@ -1,0 +1,24 @@
+import { KafkaCommand } from "../../core/domain/enums/kafka.enums";
+import { taskService } from "../../core/services/task.service";
+
+export const handleUpdateTaskTagMessage = async (message: string) => {
+    const data = JSON.parse(message);
+    console.log("Received message: ", data);
+    const cmd = data.cmd;
+    switch (cmd) {
+        case KafkaCommand.UPDATE_TASK_TAG:
+            const tasks = data.data;
+            if (Array.isArray(tasks)) {
+                for (const task of tasks) {
+                    if (task.taskId && task.tag) {
+                        await taskService.updateTaskTag(task.taskId, task.tag);
+                    } else {
+                        console.warn("Invalid task data: ", task);
+                    }
+                }
+            }
+            break;
+        default:
+            console.warn("No handler for command: ", cmd);
+    }
+}


### PR DESCRIPTION
## Summary
- add Kafka command and consumer handler to update task tags
- wire consumer into Kafka controller configuration
- support updating task tag in task service

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'express'...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa862a10f0832e9f1d2bcb88c5506e