### PR TITLE
feat(ai-core): tag schedule tasks via LLM

### DIFF
--- a/ai_core/core/domain/request/tag_schedule_task_request.py
+++ b/ai_core/core/domain/request/tag_schedule_task_request.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class TagScheduleTaskRequest(BaseModel):
+    taskId: str
+    scheduleTaskId: str
+    title: str

--- a/ai_core/core/domain/response/tag_schedule_task_response.py
+++ b/ai_core/core/domain/response/tag_schedule_task_response.py
@@ -1,0 +1,6 @@
+from core.domain.request.tag_schedule_task_request import TagScheduleTaskRequest
+
+
+class TagScheduleTaskResponse(TagScheduleTaskRequest):
+    tag: str
+

--- a/ai_core/core/prompts/task_tagging_prompt.py
+++ b/ai_core/core/prompts/task_tagging_prompt.py
@@ -1,0 +1,9 @@
+TAG_SCHEDULE_TASK_PROMPT = """
+You are Gaia, an assistant that assigns a concise tag describing the main category of task titles.
+Choose the best tag for each task from: {allowed_tags}.
+Given the following JSON array of tasks, return only JSON with the same tasks and an added
+"tag" field for each task.
+
+Tasks:
+{tasks_json}
+"""

--- a/ai_core/core/service/llm_business_handler_service.py
+++ b/ai_core/core/service/llm_business_handler_service.py
@@ -1,0 +1,32 @@
+import json
+from typing import List
+
+from core.domain.request.tag_schedule_task_request import TagScheduleTaskRequest
+from core.domain.response.tag_schedule_task_response import TagScheduleTaskResponse
+from core.prompts.task_tagging_prompt import TAG_SCHEDULE_TASK_PROMPT
+from kernel.config import llm_models
+from kernel.utils.parse_json import parse_json_string
+
+DEFAULT_MODEL = "gemini-2.0-flash"
+AVAILABLE_TAGS = ["work", "relax", "eat", "travel", "sleep"]
+
+
+async def tag_schedule_tasks(
+    tasks: List[TagScheduleTaskRequest],
+) -> List[TagScheduleTaskResponse]:
+    tasks_json = json.dumps([task.dict() for task in tasks], ensure_ascii=False)
+    prompt = TAG_SCHEDULE_TASK_PROMPT.format(
+        tasks_json=tasks_json, allowed_tags=", ".join(AVAILABLE_TAGS)
+    )
+
+    function = await llm_models.get_model_generate_content(
+        DEFAULT_MODEL, user_id="0", prompt=prompt
+    )
+    response = function(prompt=prompt, model_name=DEFAULT_MODEL)
+
+    try:
+        parsed = parse_json_string(response)
+    except Exception:
+        parsed = []
+
+    return [TagScheduleTaskResponse(**item) for item in parsed]

--- a/ai_core/index.py
+++ b/ai_core/index.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 import uvicorn
 
-from ui.controller import chat_controller, onboarding_controller, rag_controller
+from ui.controller import chat_controller, onboarding_controller, rag_controller, llm_business_handler_controller
 from infrastructure.kafka.consumer import consume
 from kernel.config.config import session_id_var
 
@@ -27,6 +27,7 @@ app.add_middleware(
 app.include_router(chat_controller.ChatRouter)
 app.include_router(onboarding_controller.OnboardingRouter)
 app.include_router(rag_controller.RagRouter)
+app.include_router(llm_business_handler_controller.LLMBusinessHandlerRouter)
 
 # Middleware
 @app.middleware("http")

--- a/ai_core/ui/controller/llm_business_handler_controller.py
+++ b/ai_core/ui/controller/llm_business_handler_controller.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+
+from core.domain.request.tag_schedule_task_request import TagScheduleTaskRequest
+from core.domain.response.base_response import return_success_response
+from core.service.llm_business_handler_service import tag_schedule_tasks
+
+LLMBusinessHandlerRouter = APIRouter(
+    prefix="/llm-business-handler",
+    tags=["LLM Business Handler"],
+)
+
+@LLMBusinessHandlerRouter.post("/tag-schedule-task")
+async def tag_schedule_task(tasks: List[TagScheduleTaskRequest]):
+    try:
+        result = await tag_schedule_tasks(tasks)
+        return return_success_response(
+            status_message="Tagged tasks successfully",
+            data=result
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- batch tag schedule tasks in a single LLM call and return each task with an added tag field
- define allowed task tags (work, relax, eat, travel, sleep)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa85955ed0832e955110a3191b8ac5