### PR TITLE
feat: add project list screen

### DIFF
--- a/mobile_app/app/_layout.tsx
+++ b/mobile_app/app/_layout.tsx
@@ -38,6 +38,10 @@ export default function RootLayout() {
 			<Stack>
 				<Stack.Screen name="index" options={{ headerShown: false }} />
 				<Stack.Screen
+					name="projects/index"
+					options={{ title: "Projects" }}
+				/>
+				<Stack.Screen
 					name="auth/login"
 					options={{ headerShown: false }}
 				/>

--- a/mobile_app/app/index.tsx
+++ b/mobile_app/app/index.tsx
@@ -56,6 +56,9 @@ export default function HomeScreen() {
 					<Text style={homeStyle.title}>
 						Welcome to GAIA, {user?.name}!
 					</Text>
+					<Link href="/projects" style={homeStyle.link}>
+						<Text style={homeStyle.linkText}>View Projects</Text>
+					</Link>
 					<Button
 						title="Logout"
 						onPress={() => {

--- a/mobile_app/app/projects/index.tsx
+++ b/mobile_app/app/projects/index.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from "react";
+import { View, Text, FlatList } from "react-native";
+import { useAppDispatch, useAppSelector } from "@/src/hooks/reduxHooks";
+import { fetchProjects } from "@/src/features/project/projectSlice";
+import LoadingIndicator from "@/src/components/common/LoadingIndicator";
+import projectStyle from "@/src/features/project/projectStyle";
+
+export default function ProjectsScreen() {
+	const dispatch = useAppDispatch();
+	const { token } = useAppSelector((state) => state.login);
+	const { projects, loading, error } = useAppSelector(
+		(state) => state.projects,
+	);
+
+	useEffect(() => {
+		if (token) {
+			dispatch(fetchProjects());
+		}
+	}, [dispatch, token]);
+
+	if (!token) {
+		return (
+			<View style={projectStyle.container}>
+				<Text style={projectStyle.title}>
+					Please login to view projects.
+				</Text>
+			</View>
+		);
+	}
+
+	return (
+		<View style={projectStyle.container}>
+			{loading ? (
+				<LoadingIndicator />
+			) : error ? (
+				<Text style={projectStyle.errorText}>{error}</Text>
+			) : (
+				<FlatList
+					data={projects}
+					keyExtractor={(item) => item.id.toString()}
+					renderItem={({ item }) => (
+						<View style={projectStyle.projectContainer}>
+							<Text style={projectStyle.projectName}>
+								{item.name}
+							</Text>
+							{item.tasks.map((task) => (
+								<Text
+									key={task.id}
+									style={projectStyle.taskName}
+								>
+									- {task.name}
+								</Text>
+							))}
+						</View>
+					)}
+				/>
+			)}
+		</View>
+	);
+}

--- a/mobile_app/src/features/project/projectSlice.ts
+++ b/mobile_app/src/features/project/projectSlice.ts
@@ -1,0 +1,88 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { get } from "@/src/utils/api";
+import type { RootState } from "@/src/store";
+
+interface Task {
+	id: number;
+	name: string;
+}
+
+interface Project {
+	id: number;
+	name: string;
+	tasks: Task[];
+}
+
+interface ProjectsState {
+	loading: boolean;
+	projects: Project[];
+	error: string | null;
+}
+
+const initialState: ProjectsState = {
+	loading: false,
+	projects: [],
+	error: null,
+};
+
+export const fetchProjects = createAsyncThunk<
+	Project[],
+	void,
+	{ state: RootState; rejectValue: string }
+>("projects/fetchProjects", async (_, { getState, rejectWithValue }) => {
+	try {
+		const token = getState().login.token;
+		if (!token) throw new Error("No token");
+
+		const projectResponse = (await get("/project/all", {
+			headers: { Authorization: `Bearer ${token}` },
+		})) as { data: { listAllProjectsByUserId: any[] } };
+		const projects = projectResponse.data.listAllProjectsByUserId || [];
+
+		const projectsWithTasks = await Promise.all(
+			projects.map(async (project: any) => {
+				const taskResponse = (await get(
+					`/project/${project.id}/group-tasks`,
+					{
+						headers: { Authorization: `Bearer ${token}` },
+					},
+				)) as { data: { getGroupTasksInProject: any[] } };
+				return {
+					...project,
+					tasks: taskResponse.data.getGroupTasksInProject || [],
+				};
+			}),
+		);
+
+		return projectsWithTasks;
+	} catch (error: any) {
+		return rejectWithValue(
+			error.response && error.response.data.message
+				? error.response.data.message
+				: error.message,
+		);
+	}
+});
+
+const projectSlice = createSlice({
+	name: "projects",
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder
+			.addCase(fetchProjects.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(fetchProjects.fulfilled, (state, action) => {
+				state.loading = false;
+				state.projects = action.payload;
+			})
+			.addCase(fetchProjects.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.payload as string;
+			});
+	},
+});
+
+export default projectSlice.reducer;

--- a/mobile_app/src/features/project/projectStyle.ts
+++ b/mobile_app/src/features/project/projectStyle.ts
@@ -1,0 +1,43 @@
+import { colors, fonts, sizes } from "@/src/constants/theme";
+import { StyleSheet } from "react-native";
+
+const projectStyle = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: colors.dark,
+		padding: sizes.large,
+	},
+	title: {
+		fontSize: sizes.large,
+		fontFamily: fonts.family.bold,
+		color: colors.light,
+		marginBottom: sizes.large,
+		textAlign: "center",
+	},
+	projectContainer: {
+		marginBottom: sizes.large,
+		backgroundColor: colors.light,
+		padding: sizes.medium,
+		borderRadius: sizes.small,
+	},
+	projectName: {
+		fontSize: sizes.medium,
+		fontFamily: fonts.family.medium,
+		color: colors.black,
+		marginBottom: sizes.small,
+	},
+	taskName: {
+		fontSize: sizes.small + 2,
+		fontFamily: fonts.family.regular,
+		color: colors.black,
+		marginLeft: sizes.small,
+	},
+	errorText: {
+		color: colors.light,
+		fontSize: sizes.medium,
+		fontFamily: fonts.family.regular,
+		textAlign: "center",
+	},
+});
+
+export default projectStyle;

--- a/mobile_app/src/store/index.ts
+++ b/mobile_app/src/store/index.ts
@@ -2,13 +2,15 @@ import { configureStore } from "@reduxjs/toolkit";
 import loginReducer from "../features/auth/loginSlice";
 import registerReducer from "../features/auth/registerSlice";
 import counterReducer from "../features/counter/counterSlice";
+import projectReducer from "../features/project/projectSlice";
 
 export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
-    login: loginReducer,
-    register: registerReducer,
-  },
+	reducer: {
+		counter: counterReducer,
+		login: loginReducer,
+		register: registerReducer,
+		projects: projectReducer,
+	},
 });
 
 // Types for later use in hooks


### PR DESCRIPTION
## Summary
- add route to list projects and tasks in mobile app
- wire up Redux slice to fetch projects and related tasks
- link project screen into home and navigation stack

## Testing
- `npm run lint` *(fails: expo not found / 403 when invoking npx expo lint)*

------
https://chatgpt.com/codex/tasks/task_e_68badcc13d24832eb97a9d3c52fb31a9