### PR TITLE
feat: add reload mode to daily calendar

### DIFF
--- a/client_gui/src/screens/dashboardScreen/DailyCalendar.jsx
+++ b/client_gui/src/screens/dashboardScreen/DailyCalendar.jsx
@@ -11,6 +11,7 @@ const DailyCalendar = () => {
 
     const [dailyTasksRequest, setDailyTasksRequest] = useState({ tasks: [] });
     const [dailyCalendar, setDailyCalendar] = useState([]);
+    const [reload, setReload] = useState(false);
 
     const timeBubbleConfigList = useSelector((state) => state.getTimeBubbleConfig);
     const { config: timeBubbleConfig, loading: loadingBubble, error: errorBubble } = timeBubbleConfigList;
@@ -46,6 +47,13 @@ const DailyCalendar = () => {
     useEffect(() => {
         fetchDailyTaskList();
     }, [fetchDailyTaskList]);
+
+    useEffect(() => {
+        if (reload) {
+            dispatch(getDailyTasksAction());
+            setReload(false);
+        }
+    }, [reload, dispatch]);
 
     useEffect(() => {
         if (dailyTasks?.tasks &&
@@ -158,7 +166,11 @@ const DailyCalendar = () => {
                             dailyCalendar && dailyCalendar?.length > 0 && (
                                 dailyCalendar ?? []).map((slot) => (
                                     <Col numColSpan={12} key={slot.id}>
-                                        <ScheduleDayBubble slot={slot} scheduleTaskList={activeTaskBatch}/>
+                                        <ScheduleDayBubble
+                                            slot={slot}
+                                            scheduleTaskList={activeTaskBatch}
+                                            onReload={() => setReload(true)}
+                                        />
                                     </Col>
                                 ))}
                     </>

--- a/client_gui/src/screens/dashboardScreen/ScheduleDayBubble.jsx
+++ b/client_gui/src/screens/dashboardScreen/ScheduleDayBubble.jsx
@@ -11,7 +11,7 @@ import { ColorBadge } from "../../components/subComponents/ColorBadge";
 import { shortenTitle } from "../../kernels/utils/field-utils";
 
 const ScheduleDayBubble = (props) => {
-    const {slot, scheduleTaskList } = props;
+    const {slot, scheduleTaskList, onReload } = props;
 
     const dispatch = useDispatch();
 
@@ -100,6 +100,7 @@ const ScheduleDayBubble = (props) => {
         console.log("update form: ", form);
         updateTimeBubble(form);
         closeModal();
+        onReload?.();
     };
 
     const handleDeleteTask = async (e) => {


### PR DESCRIPTION
## Summary
- add reload state in DailyCalendar to refresh tasks
- trigger parent reload when a time bubble is edited

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React hooks warnings, unused variables, no-undef errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c8cb50d4832ea17c2c6e029920ce