### PR TITLE
Fix proactive_thinker Neo4j integration

### DIFF
--- a/proactive_thinker/index.py
+++ b/proactive_thinker/index.py
@@ -11,8 +11,10 @@ from ui.controller import graphdb_controller
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Connect to GraphDB
-    driver = get_neo4j_driver()
+    driver_initialized = False
     try:
+        driver = get_neo4j_driver()
+        driver_initialized = True
         await driver.verify_connectivity()
         print("Connected to Neo4j database successfully.")
     except Exception as e:
@@ -22,12 +24,12 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    try:
-        driver = get_neo4j_driver()
-        await close_neo4j_driver(driver)
-        print("Disconnected from Neo4j database.")
-    except Exception as e:
-        print(f"Failed to close Neo4j database connection: {e}")
+    if driver_initialized:
+        try:
+            await close_neo4j_driver()
+            print("Disconnected from Neo4j database.")
+        except Exception as e:
+            print(f"Failed to close Neo4j database connection: {e}")
 
 app = FastAPI(title="Task Information Extraction API", lifespan=lifespan)
 

--- a/proactive_thinker/infrastructure/graphdb/graphdb_connection.py
+++ b/proactive_thinker/infrastructure/graphdb/graphdb_connection.py
@@ -1,30 +1,37 @@
-from neo4j import GraphDatabase, Driver
 from functools import lru_cache
+from typing import AsyncGenerator
+
+from neo4j import AsyncDriver, AsyncGraphDatabase, AsyncSession
 
 from kernel.config.config import Config
 
 
 config = Config()
 
-@lru_cache()
-def get_neo4j_driver() -> Driver:
-    """Creates a Neo4j driver with connection details from environment variables."""
+
+@lru_cache(maxsize=1)
+def get_neo4j_driver() -> AsyncDriver:
+    """Create a Neo4j async driver with connection details from environment variables."""
     uri = config.NEO4J_URI
     username = config.NEO4J_USER
     password = config.NEO4J_PASSWORD
-    
+
     if not all([uri, username, password]):
         raise ValueError("Neo4j environment variables are not set correctly.")
-    
-    return GraphDatabase.driver(uri, auth=(username, password))
 
-async def close_neo4j_driver(driver: Driver):
-    """Closes the Neo4j driver connection."""
-    if driver:
+    return AsyncGraphDatabase.driver(uri, auth=(username, password))
+
+
+async def close_neo4j_driver() -> None:
+    """Close the cached Neo4j driver connection if it exists."""
+    if get_neo4j_driver.cache_info().currsize:
+        driver = get_neo4j_driver()
         await driver.close()
+        get_neo4j_driver.cache_clear()
 
-async def get_db_session():
-    """Dependency that provides a Neo4j session and handles its closure."""
+
+async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency that provides a Neo4j async session and handles its closure."""
     driver = get_neo4j_driver()
     session = driver.session()
     try:

--- a/proactive_thinker/requirements.txt
+++ b/proactive_thinker/requirements.txt
@@ -14,3 +14,4 @@ starlette==0.47.3
 typing-inspection==0.4.1
 typing_extensions==4.15.0
 uvicorn==0.35.0
+neo4j==5.27.0

--- a/proactive_thinker/ui/controller/graphdb_controller.py
+++ b/proactive_thinker/ui/controller/graphdb_controller.py
@@ -1,6 +1,5 @@
 from neo4j import AsyncSession
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi import APIRouter, Depends, FastAPI, status
 from pydantic import BaseModel
 
 from infrastructure.graphdb.graphdb_connection import get_db_session
@@ -24,6 +23,8 @@ async def add_label(body: LabelRequestBody, session: AsyncSession = Depends(get_
     try:
         result = await session.run(query, name=body.label, email=body.obj)
         record = await result.single()
+        if not record:
+            raise RuntimeError("No result returned from Neo4j")
         return {"message": "User created successfully", "user": record["u"]}
     except Exception as e:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- add the official Neo4j Python driver and expose configuration through an async driver helper
- update the FastAPI lifespan hook to verify connectivity and close the cached driver cleanly
- tighten the GraphDB controller to use async sessions and validate query results

## Testing
- make run *(fails in container: ModuleNotFoundError: No module named 'neo4j' because dependency install is blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c98d82fb64832eb1e0085154fd1ec4